### PR TITLE
Allows empty response from Nessus + unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-composer.phar
+.idea/
 vendor/
+composer.phar
 composer.lock
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "leonjza/php-nessus-ng",
     "description": "PHP wrapper functions for interfacing with the Nessus V6.x API",
     "require": {
-        "php": ">=5.3.0, <6.0.0",
+        "php": ">=5.3.0",
         "guzzlehttp/guzzle": "~3.0"
     },
     "license": "MIT",
@@ -10,6 +10,10 @@
         {
             "name": "Leon Jacobs",
             "email": "leonja511@gmail.com"
+        },
+        {
+            "name": "Peter Scopes",
+            "email": "peter.scopes@gmail.com"
         }
     ],
     "minimum-stability": "stable",

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,10 @@
         "php": ">=5.3.0",
         "guzzlehttp/guzzle": "~3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~5.0",
+        "mockery/mockery": "0.9.*"
+    },
     "license": "MIT",
     "authors": [
         {
@@ -21,5 +25,10 @@
         "psr-0": {
             "Nessus": "src/"
         }
+    },
+    "autoload-dev": {
+        "classmap": [
+            "tests/TestCase.php"
+        ]
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+
+        <testsuite name="PHPNessusNG Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/unit</directory>
+        </testsuite>
+
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./app</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Nessus/Client.php
+++ b/src/Nessus/Client.php
@@ -140,10 +140,10 @@ Class Client
      * @param   string $user  The username to authenticate with
      * @param   string $pass  The password to authenticate with
      * @param   string $host  The Nessus Scanner
-     * @param   string $port  The The port the Nessus Scanner is listening on
+     * @param   int    $port  The The port the Nessus Scanner is listening on
      * @param   bool   $https Should the connection be via HTTPs
      *
-     * @return void
+     * @throws Exception\InvalidUrl If the constructed URL is invalid
      */
     public function __construct($user, $pass, $host, $port = 8834, $https = true)
     {
@@ -188,6 +188,8 @@ Class Client
      * @param   string $password The password to authenticate with if needed
      *
      * @return  $this
+     *
+     * @throws Exception\ProxyError If the port is invalid or the host is null
      */
     public function configureProxy($host, $port, $username = null, $password = null)
     {
@@ -214,6 +216,8 @@ Class Client
      * @param   bool $use Specify the use of the proxy server via true
      *
      * @return  $this
+     *
+     * @throws Exception\ProxyError if the host or port is null
      */
     public function useProxy($use = true)
     {
@@ -245,8 +249,8 @@ Class Client
     }
 
     /**
-     * Magic method to allow API calls to be constructe via
-     * method chainging. ie: $call->server()->properties() will
+     * Magic method to allow API calls to be constructed via
+     * method chaining. ie: $call->server()->properties() will
      * result in a endpoint location of BASE_URL/server/properties/
      *
      * Magic method arguments will also be parsed as part of the call.
@@ -293,9 +297,9 @@ Class Client
      * @param   string $method The HTTP method that should be used for the call
      * @param   bool   $raw    Should the response be raw JSON
      *
-     * @throws Exception
+     * @throws \Exception
      *
-     * @return  $this
+     * @return  null|object[]|object|string NULL if empty response body was empty, string if $raw = true
      */
     public function via($method = 'get', $raw = false)
     {

--- a/src/Nessus/Client.php
+++ b/src/Nessus/Client.php
@@ -257,12 +257,12 @@ Class Client
      * ie: $call->make('server', 'properties') will result in a
      * endpoint location of BASE_URL/server/properties/
      *
-     * @param   string $location The api endpoint to call.
-     * @param   string $slug     Any arguments to parse as part of the location
+     * @param   string   $location The api endpoint to call.
+     * @param   string[] $slug     Any arguments to parse as part of the location
      *
      * @return  $this
      */
-    public function __call($location, $slug = null)
+    public function __call($location, $slug)
     {
 
         // Ensure the location is lowercase
@@ -303,6 +303,26 @@ Class Client
      */
     public function via($method = 'get', $raw = false)
     {
+        // Make the call
+        return $this->makeApiCall(new Nessus\Call(), $method, $raw);
+    }
+
+    /**
+     * Make a API call using the $method described. This is the final method
+     * that should be called to make requests. Unless $raw is set to true,
+     * the response will be a PHP \Object
+     *
+     * @param Nessus\Call $api_call Call object to perform the request with
+     * @param string      $method   The HTTP method that should be used for the call
+     * @param bool        $raw      Should the response be raw JSON
+     *
+     * @return null|object|\object[]|string
+     *
+     * @throws Exception\InvalidMethod If $method is invalid
+     * @throws \Exception              If $api_call throws an exception
+     */
+    public function makeApiCall(Nessus\Call $api_call, $method, $raw = false)
+    {
         $method = strtolower($method);
 
         if ($raw)
@@ -310,10 +330,9 @@ Class Client
 
         $valid_requests = array('get', 'post', 'put', 'delete');
         if (!in_array($method, $valid_requests))
-            throw new Exception\InvalidMethod("Invalid HTTP method '" . $method . "' specified.");
+            throw new Exception\InvalidMethod(sprintf('Invalid HTTP method "%s" specified.', $method));
 
-        // Make the call
-        $api_call = new Nessus\Call();
+
         try
         {
             $api_response = $api_call->call($method, $this);

--- a/src/Nessus/Exception/FailedNessusRequest.php
+++ b/src/Nessus/Exception/FailedNessusRequest.php
@@ -47,6 +47,7 @@ class FailedNessusRequest extends BadResponseException
     {
         $exceptionClass = __CLASS__;
 
+        /** @var BadResponseException $exception */
         $exception = new $exceptionClass($message);
         $exception->setRequest($request);
         $exception->setResponse($response);

--- a/src/Nessus/Nessus/Call.php
+++ b/src/Nessus/Nessus/Call.php
@@ -103,12 +103,27 @@ Class Call
                 );
 
             else
-                  $client->setDefaultOption(
+                $client->setDefaultOption(
                     'proxy',
                     'tcp://' . $scope->proxy_host . ':' . $scope->proxy_port
                 );
         }
 
+        return $this->request($client, $method, $scope, $no_token);
+    }
+
+    /**
+     * Makes an API call to a Nessus Scanner
+     *
+     * @param HttpClient $client   The HttpClient that should be used to make the request
+     * @param string     $method   The method that should be used in the HTTP request
+     * @param object     $scope    The scope injected from a \Nessus\Client
+     * @param bool       $no_token Should a token be used in this request
+     *
+     * @return null|object[]|object|string
+     */
+    public function request(HttpClient $client, $method, $scope, $no_token = false)
+    {
         // Only really needed by $this->token() method. Otherwise we have
         // a cyclic dependency trying to setup a token
         $cookie_header = ($no_token ? array() : array('X-Cookie' => 'token=' . $this->token($scope)));
@@ -136,8 +151,8 @@ Class Call
                         array(
                             'username'=>$scope->username,
                             'password'=>$scope->password)
-                        ), 'application/json'
-                    );
+                    ), 'application/json'
+                );
 
         } else {
 
@@ -197,7 +212,7 @@ Class Call
         if (JSON_ERROR_NONE !== json_last_error())
         {
             throw Exception\FailedNessusRequest::exceptionFactory(
-                'Failed to parse response JSON.',
+                sprintf('Failed to parse response JSON: "%s"', json_last_error_msg()),
                 $request,
                 $response
             );

--- a/src/Nessus/Nessus/Call.php
+++ b/src/Nessus/Nessus/Call.php
@@ -35,6 +35,8 @@ namespace Nessus\Nessus;
  */
 
 use Guzzle\Http\Exception\BadResponseException;
+use Guzzle\Http\Message\EntityEnclosingRequestInterface;
+use Guzzle\Http\Message\Request;
 use Nessus\Exception;
 use Guzzle\Http\Client as HttpClient;
 
@@ -72,11 +74,11 @@ Class Call
     /**
      * Makes an API call to a Nessus Scanner
      *
-     * @param  string $methid   The method that should be used in the HTTP request
+     * @param  string $method   The method that should be used in the HTTP request
      * @param  object $scope    The scope injected from a \Nessus\Client
      * @param  bool   $no_token Should a token be used in this request
      *
-     * @return string
+     * @return null|object[]|object|string
      */
     public function call($method, $scope, $no_token = false)
     {
@@ -115,6 +117,7 @@ Class Call
         // json encode this and set it
         if (in_array($method, array('put', 'post', 'delete'))) {
 
+            /** @var Request|EntityEnclosingRequestInterface $request */
             $request = $client->$method(
                 ($no_token ? 'session/' : $scope->call),    // $no_token may mean a token request
                 array_merge($cookie_header, array('Accept' => 'application/json'))
@@ -169,7 +172,7 @@ Class Call
         if (!$response->isSuccessful())
         {
             throw Exception\FailedNessusRequest::exceptionFactory(
-                'Unsuccessfull Request to [' . $method . '] ' . $scope->call,
+                'Unsuccessful Request to [' . $method . '] ' . $scope->call,
                 $request,
                 $response
             );

--- a/src/Nessus/Nessus/Call.php
+++ b/src/Nessus/Nessus/Call.php
@@ -191,12 +191,13 @@ Class Call
         // Attempt to convert the response to a JSON Object
         $json = json_decode($response->getBody());
 
-        // Check that the JSON turned into a valid Object or Array.
-        // Sadly, some calls respond with array(object(<data>)), like /scanners
-        if (!is_object($json) && (!is_array($json) && count($json) <= 0 ))
+        // Check that the JSON was successfully decoded, we assume that Nessus will
+        // use HTTP status codes to inform us whether the request failed.
+        // We expect a response of either NULL, an object array, or an  object.
+        if (JSON_ERROR_NONE !== json_last_error())
         {
             throw Exception\FailedNessusRequest::exceptionFactory(
-                'Failed to parse response JSON. Consider the call with via(method, true).',
+                'Failed to parse response JSON.',
                 $request,
                 $response
             );

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Class ClientTest
+ *
+ * @package PHPNessusNG
+ * @author  Peter Scopes <@pdscopes>
+ * @license MIT
+ * @link    https://leonjza.github.io/
+ */
+class TestCase extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Tears down the fixture, for example, close a network connection.
+     * This method is called after a test is executed.
+     */
+    public function tearDown()
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+}

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Class ClientTest
+ *
+ * @package PHPNessusNG
+ * @author  Peter Scopes <@pdscopes>
+ * @license MIT
+ * @link    https://leonjza.github.io/
+ */
+class ClientTest extends TestCase
+{
+    /**
+     * @var \Mockery\Mock|\Nessus\Client
+     */
+    private $mockClient;
+
+    /**
+     * @var \Mockery\Mock|\Nessus\Nessus\Call
+     */
+    private $mockCall;
+
+    /**
+     * Sets up the fixture, for example, open a network connection.
+     * This method is called before a test is executed.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->mockClient = Mockery::mock('\Nessus\Client')->makePartial();
+        $this->mockCall   = Mockery::mock('\Nessus\Nessus\Call');
+    }
+
+
+    /**
+     * Test the via wrapper for making an API call.
+     */
+    public function testVia()
+    {
+        $this->mockClient
+            ->shouldReceive('makeApiCall')->with(Mockery::type('Nessus\Nessus\Call'), 'get', true)->andReturn(null);
+
+        $this->assertNull($this->mockClient->via('get', true));
+    }
+
+    /**
+     * Test receiving a valid response from a Nessus Call.
+     */
+    public function testMakeApiCall()
+    {
+        $this->mockClient
+            ->shouldReceive('makeNessusCall')->withNoArgs()->andReturn($this->mockCall);
+        $this->mockCall
+            ->shouldReceive('call')->with('get', $this->mockClient)->andReturn(null);
+
+        $this->assertNull($this->mockClient->makeApiCall($this->mockCall, 'get'));
+    }
+
+    /**
+     * Test sending a request with a bad method.
+     *
+     * @expectedException \Nessus\Exception\InvalidMethod
+     */
+    public function testMakeApiCallInvalidMethod()
+    {
+        $this->mockClient->via('bad_method');
+    }
+
+    /**
+     * Test sending a request that returns a BadResponseException.
+     *
+     * @expectedException \Guzzle\Http\Exception\BadResponseException
+     */
+    public function testMakeApiCallBadResponse()
+    {
+        $this->mockCall
+            ->shouldReceive('call')->with('get', $this->mockClient)->andThrow('\Guzzle\Http\Exception\BadResponseException');
+
+        $this->mockClient->makeApiCall($this->mockCall, 'get', true);
+    }
+}

--- a/tests/unit/Nessus/CallTest.php
+++ b/tests/unit/Nessus/CallTest.php
@@ -1,0 +1,339 @@
+<?php
+
+/**
+ * Class ClientTest
+ *
+ * @package PHPNessusNG
+ * @author  Peter Scopes <@pdscopes>
+ * @license MIT
+ * @link    https://leonjza.github.io/
+ */
+class CallTest extends TestCase
+{
+    /**
+     * @var \Mockery\Mock|\Nessus\Client
+     */
+    private $mockClient;
+
+    /**
+     * @var \Mockery\Mock|\Nessus\Nessus\Call
+     */
+    private $mockCall;
+
+    /**
+     * Sets up the fixture, for example, open a network connection.
+     * This method is called before a test is executed.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->mockClient = Mockery::mock('\Nessus\Client');
+        $this->mockCall   = Mockery::mock('\Nessus\Nessus\Call')->makePartial();
+    }
+
+
+    /**
+     * Test token retrieval from the Nessus Scanner.
+     */
+    public function testTokenNoToken()
+    {
+        $response = new stdClass();
+        $response->token = 'foobar';
+
+        $this->mockClient->token = null;
+        $this->mockCall
+            ->shouldReceive('call')->with('post', $this->mockClient, true)->andReturn($response);
+
+        $token = $this->mockCall->token($this->mockClient);
+
+        $this->assertEquals($response->token, $token);
+        $this->assertEquals($response->token, $this->mockClient->token);
+    }
+
+    /**
+     * Test token retrieval from Nessus Scanner - bad response exception.
+     *
+     * @expectedException \Guzzle\Http\Exception\BadResponseException
+     */
+    public function testTokenNoTokenBadResponse()
+    {
+        $response = new stdClass();
+        $response->token = 'foobar';
+
+        $this->mockClient->token = null;
+        $this->mockCall
+            ->shouldReceive('call')->with('post', $this->mockClient, true)->andThrow('\Guzzle\Http\Exception\BadResponseException');
+
+        $this->mockCall->token($this->mockClient);
+
+    }
+
+    /**
+     * Test token retrieval once token has been retrieved already.
+     */
+    public function testTokenWithToken()
+    {
+        $this->mockClient->token = 'foobar';
+        $this->mockCall
+            ->shouldNotReceive('call');
+
+        $token = $this->mockCall->token($this->mockClient);
+
+        $this->assertEquals($this->mockClient->token, $token);
+    }
+
+    /**
+     * Test call creates a Guzzle Http client and makes a request.
+     */
+    public function testCall()
+    {
+        $this->mockCall
+            ->shouldReceive('request')->with(Mockery::type('Guzzle\Http\Client'), 'get', $this->mockClient, false);
+
+        $this->mockCall->call('get', $this->mockClient);
+    }
+
+    /**
+     * Test successful GET request.
+     */
+    public function testGetRequest()
+    {
+        $this->mockClient->call = 'foobar/';
+        $headers = array('X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json');
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        $mockHttpResponse
+            ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200)
+            ->shouldReceive('isSuccessful')->withNoArgs()->andReturn(true)
+            ->shouldReceive('getBody')->withNoArgs()->andReturn(json_encode(array('1','2','3')));
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
+        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
+        $mockHttpRequest
+            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        $mockHttpClient
+            ->shouldReceive('get')->with($this->mockClient->call, $headers,  $this->mockClient->fields)->andReturn($mockHttpRequest);
+
+
+        $this->mockCall
+            ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
+
+
+        $this->assertEquals(array('1','2','3'), $this->mockCall->request($mockHttpClient, 'get', $this->mockClient));
+    }
+
+    /**
+     * Test successful POST request.
+     */
+    public function testPostRequest()
+    {
+        $this->mockClient->call = 'foobar/';
+        $headers = array('X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json');
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        $mockHttpResponse
+            ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200)
+            ->shouldReceive('isSuccessful')->withNoArgs()->andReturn(true)
+            ->shouldReceive('getBody')->withNoArgs()->andReturn(json_encode(array('1','2','3')));
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
+        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
+        $mockHttpRequest
+            ->shouldReceive('setBody')->with(json_encode($this->mockClient->fields), 'application/json')
+            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        $mockHttpClient
+            ->shouldReceive('post')->with($this->mockClient->call, $headers)->andReturn($mockHttpRequest);
+
+
+        $this->mockCall
+            ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
+
+
+        $this->assertEquals(array('1','2','3'), $this->mockCall->request($mockHttpClient, 'post', $this->mockClient));
+    }
+
+    /**
+     * Test successful session/ request.
+     */
+    public function testRequestToken()
+    {
+        $this->mockClient->username = 'foo';
+        $this->mockClient->password = 'bar';
+        $postBody = array('username' => $this->mockClient->username, 'password' => $this->mockClient->password);
+        $headers  = array('Accept' => 'application/json');
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        $mockHttpResponse
+            ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200)
+            ->shouldReceive('isSuccessful')->withNoArgs()->andReturn(true)
+            ->shouldReceive('getBody')->withNoArgs()->andReturn(json_encode(array('1','2','3')));
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
+        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
+        $mockHttpRequest
+            ->shouldReceive('setBody')->with(json_encode($postBody), 'application/json')
+            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        $mockHttpClient
+            ->shouldReceive('post')->with('session/', $headers)->andReturn($mockHttpRequest);
+
+
+        $this->mockCall
+            ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
+
+
+        $this->assertEquals(array('1','2','3'), $this->mockCall->request($mockHttpClient, 'post', $this->mockClient, true));
+    }
+
+    /**
+     * Test failed request - bad response.
+     *
+     * @expectedException \Nessus\Exception\FailedNessusRequest
+     */
+    public function testRequestBadResponse()
+    {
+        $mockHttpBadResponseException = Mockery::mock('\Guzzle\Http\Exception\BadResponseException');
+        $mockHttpBadResponseException
+            ->shouldReceive('getRequest')->withNoArgs()->andReturn(Mockery::mock('\Guzzle\Http\Message\Request'))
+            ->shouldReceive('getResponse')->withNoArgs()->andReturn(Mockery::mock('\Guzzle\Http\Message\Response'));
+
+        $this->mockClient->call = 'foobar/';
+        $headers = array('X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json');
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        $mockHttpResponse
+            ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200);
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
+        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
+        $mockHttpRequest
+            ->shouldReceive('send')->withNoArgs()->andThrow($mockHttpBadResponseException);
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        $mockHttpClient
+            ->shouldReceive('get')->with($this->mockClient->call, $headers,  $this->mockClient->fields)->andReturn($mockHttpRequest);
+
+
+        $this->mockCall
+            ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
+
+
+        $this->assertEquals(array('1','2','3'), $this->mockCall->request($mockHttpClient, 'get', $this->mockClient));
+    }
+
+    /**
+     * Test failed request - 404 not found.
+     *
+     * @expectedException \Nessus\Exception\FailedNessusRequest
+     */
+    public function testRequestNotFound()
+    {
+        $this->mockClient->call = 'foobar/';
+        $headers = array('X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json');
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        $mockHttpResponse
+            ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(404);
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
+        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
+        $mockHttpRequest
+            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        $mockHttpClient
+            ->shouldReceive('get')->with($this->mockClient->call, $headers,  $this->mockClient->fields)->andReturn($mockHttpRequest);
+
+
+        $this->mockCall
+            ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
+
+
+        $this->assertEquals(array('1','2','3'), $this->mockCall->request($mockHttpClient, 'get', $this->mockClient));
+    }
+
+    /**
+     * Test failed request - response unsuccessful.
+     *
+     * @expectedException \Nessus\Exception\FailedNessusRequest
+     */
+    public function testRequestUnsuccessfulResponse()
+    {
+        $this->mockClient->call = 'foobar/';
+        $headers = array('X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json');
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        $mockHttpResponse
+            ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200)
+            ->shouldReceive('isSuccessful')->withNoArgs()->andReturn(false);
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
+        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
+        $mockHttpRequest
+            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        $mockHttpClient
+            ->shouldReceive('get')->with($this->mockClient->call, $headers,  $this->mockClient->fields)->andReturn($mockHttpRequest);
+
+
+        $this->mockCall
+            ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
+
+
+        $this->assertEquals(array('1','2','3'), $this->mockCall->request($mockHttpClient, 'get', $this->mockClient));
+    }
+
+    /**
+     * Test failed request - JSON parse error.
+     *
+     * @expectedException \Nessus\Exception\FailedNessusRequest
+     */
+    public function testRequestFailedJsonParse()
+    {
+        $this->mockClient->call = 'foobar/';
+        $headers = array('X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json');
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        $mockHttpResponse
+            ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200)
+            ->shouldReceive('isSuccessful')->withNoArgs()->andReturn(true)
+            ->shouldReceive('getBody')->withNoArgs()->andReturn('}INVALID JSON{');
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
+        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
+        $mockHttpRequest
+            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        $mockHttpClient
+            ->shouldReceive('get')->with($this->mockClient->call, $headers,  $this->mockClient->fields)->andReturn($mockHttpRequest);
+
+
+        $this->mockCall
+            ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
+
+
+        $this->assertEquals(array('1','2','3'), $this->mockCall->request($mockHttpClient, 'get', $this->mockClient));
+    }
+}


### PR DESCRIPTION
I've done three main things to improve what is a very helpful library:

1. Allowed empty responses from Nessus by using `json_last_error()` to detect JSON parsing failures.
 - Some Nessus responses are legitely empty, e.g. `DELETE /scans/{scan_id}`
 - Having to add the `$raw = true` seems like a ugly way of resolving this
2. Removed the upperbound restriction in `composer.json` for PHP
3. Added units tests (this did result in some code refactoring)

Please consider approving this pull request.

Kind regards.