### PR TITLE
Proper handling of empty responses

### DIFF
--- a/src/Nessus/Nessus/Call.php
+++ b/src/Nessus/Nessus/Call.php
@@ -204,7 +204,7 @@ Class Call
 
         // We assume that Nessus can return empty bodies and that Nessus will
         // use HTTP status codes to inform us whether the request failed.
-        if (trim($response->getBody()) == '' )
+        if (trim($response->getBody()) == '')
             return null;
 
         // Attempt to convert the response to a JSON Object

--- a/src/Nessus/Nessus/Call.php
+++ b/src/Nessus/Nessus/Call.php
@@ -202,12 +202,16 @@ Class Call
         if (is_null($response->getBody()) || trim($response->getBody()) == 'null')
             return null;
 
+        // We assume that Nessus can return empty bodies and that Nessus will
+        // use HTTP status codes to inform us whether the request failed.
+        if (trim($response->getBody()) == '' )
+            return null;
+
         // Attempt to convert the response to a JSON Object
         $json = json_decode($response->getBody());
 
-        // Check that the JSON was successfully decoded, we assume that Nessus will
-        // use HTTP status codes to inform us whether the request failed.
-        // We expect a response of either NULL, an object array, or an  object.
+        // Check that the JSON was successfully decoded.
+        // We expect a response of either an object array or an object.
         if (JSON_ERROR_NONE !== json_last_error()) {
             throw Exception\FailedNessusRequest::exceptionFactory(
                 sprintf('Failed to parse response JSON: "%s"', json_last_error_msg()),

--- a/tests/unit/Nessus/CallTest.php
+++ b/tests/unit/Nessus/CallTest.php
@@ -104,7 +104,6 @@ class CallTest extends TestCase
      */
     public function testGetRequest()
     {
-
         $this->mockClient->call = 'foobar/';
         $headers = ['X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json'];
 
@@ -129,6 +128,37 @@ class CallTest extends TestCase
             ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
 
         $this->assertEquals(['1', '2', '3'], $this->mockCall->request($mockHttpClient, 'get', $this->mockClient));
+    }
+
+    /**
+     * Test successful GET request - empty response.
+     */
+    public function testGetRequestEmptyResponse()
+    {
+        $this->mockClient->call = 'foobar/';
+        $headers = ['X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json'];
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        $mockHttpResponse
+            ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200)
+            ->shouldReceive('isSuccessful')->withNoArgs()->andReturn(true)
+            ->shouldReceive('getBody')->withNoArgs()->andReturn('');
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
+        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
+        $mockHttpRequest
+            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        $mockHttpClient
+            ->shouldReceive('get')->with($this->mockClient->call, $headers, $this->mockClient->fields)->andReturn($mockHttpRequest);
+
+        $this->mockCall
+            ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
+
+        $this->assertNull($this->mockCall->request($mockHttpClient, 'get', $this->mockClient));
     }
 
     /**
@@ -192,7 +222,39 @@ class CallTest extends TestCase
         $this->mockCall
             ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
 
-        $this->assertEquals(null, $this->mockCall->request($mockHttpClient, 'put', $this->mockClient));
+        $this->assertNull($this->mockCall->request($mockHttpClient, 'put', $this->mockClient));
+    }
+
+    /**
+     * Test successful POST request with an empty response.
+     */
+    public function testPostRequestEmptyResponse()
+    {
+        $this->mockClient->call = 'foobar/';
+        $headers = ['X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json'];
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        $mockHttpResponse
+            ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200)
+            ->shouldReceive('isSuccessful')->withNoArgs()->andReturn(true)
+            ->shouldReceive('getBody')->withNoArgs()->andReturn('');
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
+        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
+        $mockHttpRequest
+            ->shouldReceive('setBody')->with(json_encode($this->mockClient->fields), 'application/json')
+            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        $mockHttpClient
+            ->shouldReceive('post')->with($this->mockClient->call, $headers)->andReturn($mockHttpRequest);
+
+        $this->mockCall
+            ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
+
+        $this->assertNull($this->mockCall->request($mockHttpClient, 'post', $this->mockClient));
     }
 
     /**
@@ -224,7 +286,7 @@ class CallTest extends TestCase
         $this->mockCall
             ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
 
-        $this->assertEquals(null, $this->mockCall->request($mockHttpClient, 'delete', $this->mockClient));
+        $this->assertNull($this->mockCall->request($mockHttpClient, 'delete', $this->mockClient));
     }
 
     /**
@@ -365,13 +427,12 @@ class CallTest extends TestCase
     }
 
     /**
-     * Test failed request - JSON parse error.
+     * Test failed request - JSON parse error (syntax error).
      *
      * @expectedException \Nessus\Exception\FailedNessusRequest
      */
     public function testRequestFailedJsonParse()
     {
-
         $this->mockClient->call = 'foobar/';
         $headers = ['X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json'];
 
@@ -395,6 +456,6 @@ class CallTest extends TestCase
         $this->mockCall
             ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
 
-        $this->assertEquals(['1', '2', '3'], $this->mockCall->request($mockHttpClient, 'get', $this->mockClient));
+        $this->mockCall->request($mockHttpClient, 'get', $this->mockClient);
     }
 }

--- a/tests/unit/Nessus/CallTest.php
+++ b/tests/unit/Nessus/CallTest.php
@@ -136,7 +136,6 @@ class CallTest extends TestCase
      */
     public function testPostRequest()
     {
-
         $this->mockClient->call = 'foobar/';
         $headers = ['X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json'];
 
@@ -162,6 +161,70 @@ class CallTest extends TestCase
             ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
 
         $this->assertEquals(['1', '2', '3'], $this->mockCall->request($mockHttpClient, 'post', $this->mockClient));
+    }
+
+    /**
+     * Test successful PUT request with an empty response.
+     */
+    public function testPutRequestEmptyResponse()
+    {
+        $this->mockClient->call = 'foobar/';
+        $headers = ['X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json'];
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        $mockHttpResponse
+            ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200)
+            ->shouldReceive('isSuccessful')->withNoArgs()->andReturn(true)
+            ->shouldReceive('getBody')->withNoArgs()->andReturn('');
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
+        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
+        $mockHttpRequest
+            ->shouldReceive('setBody')->with(json_encode($this->mockClient->fields), 'application/json')
+            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        $mockHttpClient
+            ->shouldReceive('put')->with($this->mockClient->call, $headers)->andReturn($mockHttpRequest);
+
+        $this->mockCall
+            ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
+
+        $this->assertEquals(null, $this->mockCall->request($mockHttpClient, 'put', $this->mockClient));
+    }
+
+    /**
+     * Test successful PUT request with an empty response.
+     */
+    public function testDeleteRequestEmptyResponse()
+    {
+        $this->mockClient->call = 'foobar/';
+        $headers = ['X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json'];
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        $mockHttpResponse
+            ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200)
+            ->shouldReceive('isSuccessful')->withNoArgs()->andReturn(true)
+            ->shouldReceive('getBody')->withNoArgs()->andReturn('');
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
+        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
+        $mockHttpRequest
+            ->shouldReceive('setBody')->with(json_encode($this->mockClient->fields), 'application/json')
+            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
+
+        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        $mockHttpClient
+            ->shouldReceive('delete')->with($this->mockClient->call, $headers)->andReturn($mockHttpRequest);
+
+        $this->mockCall
+            ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
+
+        $this->assertEquals(null, $this->mockCall->request($mockHttpClient, 'delete', $this->mockClient));
     }
 
     /**


### PR DESCRIPTION
Hi again,

Embarrassingly, it seems that I did not properly fix the problem with empty responses with my first pull request. I have now corrected myself, sorry for the inconvenience I've caused!

It turns out `json_decode('')` causes `json_last_error()` and `json_last_error_msg()` to response with `4` and `Syntax Error` respectively. To resolve to issue I added an extra conditional check for empty strings before the `json_decode`.