### PR TITLE
Feature/guzzlehttp upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP wrapper functions for interfacing with the Nessus V6.x API",
     "require": {
         "php": ">=5.6.0",
-        "guzzlehttp/guzzle": "~3.0"
+        "guzzlehttp/guzzle": "~5.3|~6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP wrapper functions for interfacing with the Nessus V6.x API",
     "require": {
         "php": ">=5.6.0",
-        "guzzlehttp/guzzle": "~5.3|~6.0"
+        "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0",

--- a/examples/scans.php
+++ b/examples/scans.php
@@ -17,7 +17,7 @@ echo '[+] Scans Timestamp: ' . $scans->timestamp . PHP_EOL;
 $scan_id = null;
 if (null !== $scans->scans) {
     foreach ($scans->scans as $scan) {
-        print '[+] Scan ' . $scan->id . ': (' . $scan->name . ') status: ' . $scan->status . PHP_EOL;
+        echo '[+] Scan ' . $scan->id . ': (' . $scan->name . ') status: ' . $scan->status . PHP_EOL;
         if ('completed' == $scan->status) {
             $scan_id = $scan->id;
         }
@@ -30,13 +30,13 @@ if (null !== $scans->scans) {
 
 if (null !== $scan_id) {
     // Lets take the first scan from the previous request
-    print '[+] Using scan_id: ' . $scan_id . ' for export.' . PHP_EOL;
+    echo '[+] Using scan_id: ' . $scan_id . ' for export.' . PHP_EOL;
 
     // Schedule the export in .nessus format, taking note of
     // the returned file_id
     // POST /scans/{scan_id}/export
     $file_id = $nessus->scans($scan_id)->export()->setFields(['format' => 'nessus'])->via('post')->file;
-    print '[+] Got file_id: ' . $file_id . ' for export job.' . PHP_EOL;
+    echo '[+] Got file_id: ' . $file_id . ' for export job.' . PHP_EOL;
 
     // We now have to wait for the export to complete. We are
     // just going to check the status of our export every 1 second
@@ -45,7 +45,7 @@ if (null !== $scan_id) {
 
         // Poll for a status update
         $export_status = $nessus->scans($scan_id)->export($file_id)->status()->via('get')->status;
-        print '[+] Export status is: ' . $export_status . PHP_EOL;
+        echo '[+] Export status is: ' . $export_status . PHP_EOL;
 
         // Wait 1 second before another poll
         sleep(1);
@@ -53,21 +53,21 @@ if (null !== $scan_id) {
 
     // Once the export == 'ready', download it!
     $file = $nessus->scans($scan_id)->export($file_id)->download()->via('get', true);
-    print '[+] Report downloaded.' . PHP_EOL;
-    print '[+] Start report sample (first 250 chars): ' . PHP_EOL;
-    print substr($file, 0, 250) . PHP_EOL;
-    print '[+] End report sample: ' . PHP_EOL;
+    echo '[+] Report downloaded.' . PHP_EOL;
+    echo '[+] Start report sample (first 250 chars): ' . PHP_EOL;
+    echo substr($file, 0, 250) . PHP_EOL;
+    echo '[+] End report sample: ' . PHP_EOL;
 
     // Get the scan details for $scan_id
     // GET /scans/{scan_id}
     $scan_details = $nessus->scans($scan_id)->via('get');
-    print '[+] Report name ' . $scan_id . ': ' . $scan_details->info->name . PHP_EOL;
-    print '[+] Report targets ' . $scan_id . ': ' . $scan_details->info->targets . PHP_EOL;
-    print '[+] Scanner name ' . $scan_id . ': ' . $scan_details->info->scanner_name . PHP_EOL;
+    echo '[+] Report name ' . $scan_id . ': ' . $scan_details->info->name . PHP_EOL;
+    echo '[+] Report targets ' . $scan_id . ': ' . $scan_details->info->targets . PHP_EOL;
+    echo '[+] Scanner name ' . $scan_id . ': ' . $scan_details->info->scanner_name . PHP_EOL;
 
-    print '[+] Hosts for report ' . $scan_id . PHP_EOL;
+    echo '[+] Hosts for report ' . $scan_id . PHP_EOL;
     foreach ($scan_details->hosts as $host) {
-        print '[+] ' . $host->host_id . ', ' . $host->hostname . ', Severity rating: ' . $host->severity . PHP_EOL;
+        echo '[+] ' . $host->host_id . ', ' . $host->hostname . ', Severity rating: ' . $host->severity . PHP_EOL;
     }
 }
 
@@ -79,14 +79,14 @@ if (null !== $scan_id) {
 $policies = $nessus->policies()->via('get');
 if (null !== $policies->policies) {
     foreach ($policies->policies as $policy) {
-        print '[+] Policy name ' . $policy->name . ' with UUID ' . $policy->template_uuid . PHP_EOL;
+        echo '[+] Policy name ' . $policy->name . ' with UUID ' . $policy->template_uuid . PHP_EOL;
     }
 }
 
 // Just take the first policies template uuid
 $templates = $nessus->editor('policy')->templates()->via('get');
 $template_uuid = $templates->templates[0]->uuid;
-print '[+] Will use template_uuid' . $template_uuid . PHP_EOL;
+echo '[+] Will use template_uuid' . $template_uuid . PHP_EOL;
 
 // Add a new scan
 // POST /scans
@@ -119,7 +119,7 @@ while ('running' !== $scan_details->info->status) {
     sleep(0.5);
     $scan_details = $nessus->scans($new_scan->id)->via('get');
 }
-print '[+] Scan ' . $new_scan->id . ' is for scanner ' . $scan_details->info->scanner_name . ' and is ' . $scan_details->info->status . PHP_EOL;
+echo '[+] Scan ' . $new_scan->id . ' is for scanner ' . $scan_details->info->scanner_name . ' and is ' . $scan_details->info->status . PHP_EOL;
 
 // Pause the scan
 $pause_scan = $nessus->scans($new_scan->id)->pause()->via('post');
@@ -129,7 +129,7 @@ while ('paused' !== $scan_details->info->status) {
     sleep(0.5);
     $scan_details = $nessus->scans($new_scan->id)->via('get');
 }
-print '[+] Scan ' . $new_scan->id . ' is for scanner ' . $scan_details->info->scanner_name . ' and is ' . $scan_details->info->status . PHP_EOL;
+echo '[+] Scan ' . $new_scan->id . ' is for scanner ' . $scan_details->info->scanner_name . ' and is ' . $scan_details->info->status . PHP_EOL;
 
 // stop the scan
 $stop_scan = $nessus->scans($new_scan->id)->stop()->via('post');
@@ -140,11 +140,11 @@ while ('canceled' !== $scan_details->info->status) {
     $scan_details = $nessus->scans($new_scan->id)->via('get');
 }
 $scan_details = $nessus->scans($new_scan->id)->via('get');
-print '[+] Scan ' . $new_scan->id . ' is for scanner ' . $scan_details->info->scanner_name . ' and is ' . $scan_details->info->status . PHP_EOL;
+echo '[+] Scan ' . $new_scan->id . ' is for scanner ' . $scan_details->info->scanner_name . ' and is ' . $scan_details->info->status . PHP_EOL;
 
 // Delete the scan
 $deleted_scan = $nessus->scans($new_scan->id)->via('delete');
-print '[+] Deleted scan ' . $new_scan->id . PHP_EOL;
+echo '[+] Deleted scan ' . $new_scan->id . PHP_EOL;
 
 // Sample output
 

--- a/examples/scans.php
+++ b/examples/scans.php
@@ -15,10 +15,12 @@ print '[+] Scans Timestamp: ' . $scans->timestamp . PHP_EOL;
 
 // Loop over the scans printing some information
 $scan_id = null;
-foreach ($scans->scans as $scan) {
-    print '[+] Scan ' . $scan->id . ': (' . $scan->name . ') status: ' . $scan->status . PHP_EOL;
-    if ('completed' == $scan->status) {
-        $scan_id = $scan->id;
+if (null !== $scans->scans) {
+    foreach ($scans->scans as $scan) {
+        print '[+] Scan ' . $scan->id . ': (' . $scan->name . ') status: ' . $scan->status . PHP_EOL;
+        if ('completed' == $scan->status) {
+            $scan_id = $scan->id;
+        }
     }
 }
 
@@ -75,12 +77,15 @@ if (null !== $scan_id) {
 // Obviously, this requires us to have already set a policy up :>
 // GET /policies
 $policies = $nessus->policies()->via('get');
-foreach ($policies->policies as $policy) {
-    print '[+] Policy name ' . $policy->name . ' with UUID ' . $policy->template_uuid . PHP_EOL;
+if (null !== $policies->policies) {
+    foreach ($policies->policies as $policy) {
+        print '[+] Policy name ' . $policy->name . ' with UUID ' . $policy->template_uuid . PHP_EOL;
+    }
 }
 
 // Just take the first policies template uuid
-$template_uuid = $policies->policies[0]->template_uuid;
+$templates = $nessus->editor('policy')->templates()->via('get');
+$template_uuid = $templates->templates[0]->uuid;
 print '[+] Will use template_uuid' . $template_uuid . PHP_EOL;
 
 // Add a new scan

--- a/examples/scans.php
+++ b/examples/scans.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../vendor/autoload.php';
+include __DIR__ . '/../vendor/autoload.php';
 
 // Prepare the connection to the API
 $nessus = new Nessus\Client('username', 'password', '192.168.56.101');
@@ -14,53 +14,60 @@ $scans = $nessus->scans()->via('get');
 print '[+] Scans Timestamp: ' . $scans->timestamp . PHP_EOL;
 
 // Loop over the scans printing some information
-foreach ($scans->scans as $scan)
+$scan_id = null;
+foreach ($scans->scans as $scan) {
     print '[+] Scan ' . $scan->id . ': (' . $scan->name . ') status: ' . $scan->status . PHP_EOL;
+    if ('completed' == $scan->status) {
+        $scan_id = $scan->id;
+    }
+}
 
 // Prepare a scan for download. To do this we need to first
 // schedule a export job. Once this is done, we can download the
 // report in the requested format.
 
-// Lets take the first scan from the previous request
-$scan_id = $scans->scans[0]->id;
-print '[+] Using scan_id: ' . $scan_id . ' for export.' . PHP_EOL;
+if (null !== $scan_id) {
+    // Lets take the first scan from the previous request
+    print '[+] Using scan_id: ' . $scan_id . ' for export.' . PHP_EOL;
 
-// Schedule the export in .nessus format, taking note of
-// the returned file_id
-// POST /scans/{scan_id}/export
-$file_id = $nessus->scans($scan_id)->export()->setFields(array('format' => 'nessus'))->via('post')->file;
-print '[+] Got file_id: ' . $file_id . ' for export job.' . PHP_EOL;
+    // Schedule the export in .nessus format, taking note of
+    // the returned file_id
+    // POST /scans/{scan_id}/export
+    $file_id = $nessus->scans($scan_id)->export()->setFields(['format' => 'nessus'])->via('post')->file;
+    print '[+] Got file_id: ' . $file_id . ' for export job.' . PHP_EOL;
 
-// We now have to wait for the export to complete. We are
-// just going to check the status of our export every 1 second
-$export_status = 'waiting';
-while ($export_status != 'ready') {
+    // We now have to wait for the export to complete. We are
+    // just going to check the status of our export every 1 second
+    $export_status = 'waiting';
+    while ($export_status != 'ready') {
 
-    // Poll for a status update
-    $export_status = $nessus->scans($scan_id)->export($file_id)->status()->via('get')->status;
-    print '[+] Export status is: ' . $export_status . PHP_EOL;
+        // Poll for a status update
+        $export_status = $nessus->scans($scan_id)->export($file_id)->status()->via('get')->status;
+        print '[+] Export status is: ' . $export_status . PHP_EOL;
 
-    // Wait 0.5 second before another poll
-    sleep(0.5);
+        // Wait 1 second before another poll
+        sleep(1);
+    }
+
+    // Once the export == 'ready', download it!
+    $file = $nessus->scans($scan_id)->export($file_id)->download()->via('get', true);
+    print '[+] Report downloaded.' . PHP_EOL;
+    print '[+] Start report sample (first 250 chars): ' . PHP_EOL;
+    print substr($file, 0, 250) . PHP_EOL;
+    print '[+] End report sample: ' . PHP_EOL;
+
+    // Get the scan details for $scan_id
+    // GET /scans/{scan_id}
+    $scan_details = $nessus->scans($scan_id)->via('get');
+    print '[+] Report name ' . $scan_id . ': ' . $scan_details->info->name . PHP_EOL;
+    print '[+] Report targets ' . $scan_id . ': ' . $scan_details->info->targets . PHP_EOL;
+    print '[+] Scanner name ' . $scan_id . ': ' . $scan_details->info->scanner_name . PHP_EOL;
+
+    print '[+] Hosts for report ' . $scan_id . PHP_EOL;
+    foreach ($scan_details->hosts as $host) {
+        print '[+] ' . $host->host_id . ', ' . $host->hostname . ', Severity rating: ' . $host->severity . PHP_EOL;
+    }
 }
-
-// Once the export == 'ready', download it!
-$file = $nessus->scans($scan_id)->export($file_id)->download()->via('get', true);
-print '[+] Report downloaded.' . PHP_EOL;
-print '[+] Start report sample (first 250 chars): ' . PHP_EOL;
-print substr($file, 0, 250) . PHP_EOL;
-print '[+] End report sample: ' . PHP_EOL;
-
-// Get the scan details for $scan_id
-// GET /scans/{scan_id}
-$scan_details = $nessus->scans($scan_id)->via('get');
-print '[+] Report name ' . $scan_id . ': ' . $scan_details->info->name . PHP_EOL;
-print '[+] Report targets ' . $scan_id . ': ' . $scan_details->info->targets . PHP_EOL;
-print '[+] Scanner name ' . $scan_id . ': ' . $scan_details->info->scanner_name . PHP_EOL;
-
-print '[+] Hosts for report ' . $scan_id . PHP_EOL;
-foreach ($scan_details->hosts as $host)
-    print '[+] ' . $host->host_id . ', ' . $host->hostname . ', Severity rating: ' . $host->severity . PHP_EOL;
 
 // Create a new scan. For a new scan, we can specify a policy ID
 // as the uuid of the scan. Either that or a template UUID is fine.
@@ -68,8 +75,9 @@ foreach ($scan_details->hosts as $host)
 // Obviously, this requires us to have already set a policy up :>
 // GET /policies
 $policies = $nessus->policies()->via('get');
-foreach ($policies->policies as $policy)
-    print '[+] Policy name ' . $policy->name .  ' with UUID ' . $policy->template_uuid . PHP_EOL;
+foreach ($policies->policies as $policy) {
+    print '[+] Policy name ' . $policy->name . ' with UUID ' . $policy->template_uuid . PHP_EOL;
+}
 
 // Just take the first policies template uuid
 $template_uuid = $policies->policies[0]->template_uuid;
@@ -78,17 +86,17 @@ print '[+] Will use template_uuid' . $template_uuid . PHP_EOL;
 // Add a new scan
 // POST /scans
 $new_scan = $nessus->scans()
-            ->setFields(
-                array(
-                    'uuid' => $template_uuid,
-                    'settings' => array(
-                        'launch_now' => false,
-                        'name' => 'PHPNessusNG API Test Scan',
-                        'text_targets' => '127.0.0.1',
-                    )
-                )
-            )
-            ->via('post')->scan;
+    ->setFields(
+        [
+            'uuid'     => $template_uuid,
+            'settings' => [
+                'launch_now'   => false,
+                'name'         => 'PHPNessusNG API Test Scan',
+                'text_targets' => '127.0.0.1',
+            ],
+        ]
+    )
+    ->via('post')->scan;
 
 print '[+] Configured a new scan ' . $new_scan->id . ' with name ' . $new_scan->name . ' and UUID ' . $new_scan->uuid . PHP_EOL;
 print '[+] Scan ' . $new_scan->uuid . ' will scan ' . $new_scan->custom_targets . PHP_EOL;
@@ -102,29 +110,36 @@ $launch_scan = $nessus->scans($new_scan->id)->launch()->via('post');
 print '[+] Scan ' . $new_scan->id . ' started with UUID ' . $launch_scan->scan_uuid . PHP_EOL;
 
 // Wait 2 seconds, and re-request the status
-sleep(2);
-$scan_details = $nessus->scans($new_scan->id)->via('get');
+while ('running' !== $scan_details->info->status) {
+    sleep(0.5);
+    $scan_details = $nessus->scans($new_scan->id)->via('get');
+}
 print '[+] Scan ' . $new_scan->id . ' is for scanner ' . $scan_details->info->scanner_name . ' and is ' . $scan_details->info->status . PHP_EOL;
 
 // Pause the scan
 $pause_scan = $nessus->scans($new_scan->id)->pause()->via('post');
 
 // Wait 5 seconds, and re-request the status
-sleep(5);
-$scan_details = $nessus->scans($new_scan->id)->via('get');
+while ('paused' !== $scan_details->info->status) {
+    sleep(0.5);
+    $scan_details = $nessus->scans($new_scan->id)->via('get');
+}
 print '[+] Scan ' . $new_scan->id . ' is for scanner ' . $scan_details->info->scanner_name . ' and is ' . $scan_details->info->status . PHP_EOL;
 
 // stop the scan
 $stop_scan = $nessus->scans($new_scan->id)->stop()->via('post');
 
 // Wait 5 seconds, and re-request the status
-sleep(5);
+while ('canceled' !== $scan_details->info->status) {
+    sleep(0.5);
+    $scan_details = $nessus->scans($new_scan->id)->via('get');
+}
 $scan_details = $nessus->scans($new_scan->id)->via('get');
 print '[+] Scan ' . $new_scan->id . ' is for scanner ' . $scan_details->info->scanner_name . ' and is ' . $scan_details->info->status . PHP_EOL;
 
 // Delete the scan
 $deleted_scan = $nessus->scans($new_scan->id)->via('delete');
-print '[+] Deleted scan ' . $new_scan->id  . PHP_EOL;
+print '[+] Deleted scan ' . $new_scan->id . PHP_EOL;
 
 // Sample output
 

--- a/examples/server.php
+++ b/examples/server.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../vendor/autoload.php';
+include __DIR__ . '/../vendor/autoload.php';
 
 // Prepare the connection to the API
 $nessus = new Nessus\Client('username', 'password', '192.168.56.101');
@@ -10,9 +10,11 @@ $nessus = new Nessus\Client('username', 'password', '192.168.56.101');
 $server_properties = $nessus->server()->properties()->via('get');
 
 print '[+] Server Version: ' . $server_properties->server_version . PHP_EOL;
-print '[+] Feed: ' . $server_properties->feed . PHP_EOL;
-foreach ($server_properties->notifications as $notification)
+print '[+] Server Build: ' . $server_properties->server_build . PHP_EOL;
+print '[+] UI Version: ' . $server_properties->nessus_ui_version . PHP_EOL;
+foreach ($server_properties->notifications as $notification) {
     print '[+] Notification Type: ' . $notification->type . ' : ' . $notification->message . PHP_EOL;
+}
 
 // Get the server status
 // GET /server/status

--- a/examples/server.php
+++ b/examples/server.php
@@ -22,8 +22,6 @@ $server_status = $nessus->server()->status()->via('get');
 echo '[+] Server Progress: ' . $server_status->progress . PHP_EOL;
 echo '[+] Server Status: ' . $server_status->status . PHP_EOL;
 
-
-
 // Sample output
 // λ git n6* → php server.php
 // [+] Server Version: 6.0.0

--- a/examples/server.php
+++ b/examples/server.php
@@ -9,11 +9,11 @@ $nessus = new Nessus\Client('username', 'password', '192.168.56.101');
 // GET /server/properties
 $server_properties = $nessus->server()->properties()->via('get');
 
-print '[+] Server Version: ' . $server_properties->server_version . PHP_EOL;
-print '[+] Server Build: ' . $server_properties->server_build . PHP_EOL;
-print '[+] UI Version: ' . $server_properties->nessus_ui_version . PHP_EOL;
+echo '[+] Server Version: ' . $server_properties->server_version . PHP_EOL;
+echo '[+] Server Build: ' . $server_properties->server_build . PHP_EOL;
+echo '[+] UI Version: ' . $server_properties->nessus_ui_version . PHP_EOL;
 foreach ($server_properties->notifications as $notification) {
-    print '[+] Notification Type: ' . $notification->type . ' : ' . $notification->message . PHP_EOL;
+    echo '[+] Notification Type: ' . $notification->type . ' : ' . $notification->message . PHP_EOL;
 }
 
 // Get the server status

--- a/examples/users.php
+++ b/examples/users.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../vendor/autoload.php';
+include __DIR__ . '/../vendor/autoload.php';
 
 // Prepare the connection to the API
 $nessus = new Nessus\Client('username', 'password', '192.168.56.101');
@@ -10,37 +10,38 @@ $nessus = new Nessus\Client('username', 'password', '192.168.56.101');
 $users = $nessus->users()->via('get')->users;
 
 // ... and print some information
-foreach ($users as $user)
+foreach ($users as $user) {
     print '[+] id:' . $user->id . " - " . $user->type . ' user ' . $user->username . ' last login: ' . $user->lastlogin . PHP_EOL;
+}
 
 // Create a new user
 // POST /users
 $new_user = $nessus->users()
-                ->setFields(
-                    array(
-                        'username' => 'apiuser',
-                        'password' => 'apiuser',
-                        'permissions' => 128,   // Full permissions
-                        'name' => 'API User',
-                        'email' => 'api@hostname.local',
-                        'type' => 'local'
-                    )
-                )
-                ->via('post');
+    ->setFields(
+        [
+            'username'    => 'apiuser',
+            'password'    => 'apiuser',
+            'permissions' => 128,   // Full permissions
+            'name'        => 'API User',
+            'email'       => 'api@hostname.local',
+            'type'        => 'local',
+        ]
+    )
+    ->via('post');
 print '[+] Created new user ' . $new_user->name . ' with id ' . $new_user->id . PHP_EOL;
 
 // Edit the user
 // PUT /users/{user_id}
 //This API call appears to be broken?
 $user_edit = $nessus->users($new_user->id)
-                ->setFields(
-                    array(
-                        'permissions' => 128,
-                        'name' => 'Edited API Name',
-                        'email' => 'apiedit@hostname.local'
-                    )
-                )
-                ->via('put');
+    ->setFields(
+        [
+            'permissions' => 128,
+            'name'        => 'Edited API Name',
+            'email'       => 'apiedit@hostname.local',
+        ]
+    )
+    ->via('put');
 print '[+] Edited user ' . $new_user->id . PHP_EOL;
 
 // Delete the user

--- a/examples/users.php
+++ b/examples/users.php
@@ -11,7 +11,7 @@ $users = $nessus->users()->via('get')->users;
 
 // ... and print some information
 foreach ($users as $user) {
-    print '[+] id:' . $user->id . ' - ' . $user->type . ' user ' . $user->username . ' last login: ' . $user->lastlogin . PHP_EOL;
+    echo '[+] id:' . $user->id . ' - ' . $user->type . ' user ' . $user->username . ' last login: ' . $user->lastlogin . PHP_EOL;
 }
 
 // Create a new user

--- a/src/Nessus/Client.php
+++ b/src/Nessus/Client.php
@@ -25,7 +25,7 @@ SOFTWARE.
 
 namespace Nessus;
 
-/**
+/*
  * PHP Nessus NG
  *
  * @package  PHPNessusNG
@@ -33,9 +33,6 @@ namespace Nessus;
  * @license  MIT
  * @link     https://leonjza.github.io/
  */
-
-use Nessus\Exception;
-use Nessus\Nessus;
 
 /**
  * Class Client.
@@ -160,7 +157,7 @@ class Client
         $this->url .= ':' . $this->port . '/';
 
         // Check that we have a valid host
-        if (!filter_var($this->url, FILTER_VALIDATE_URL)) {
+        if (! filter_var($this->url, FILTER_VALIDATE_URL)) {
             throw new Exception\InvalidUrl($this->url . ' appears to be unparsable.');
         }
     }
@@ -197,7 +194,7 @@ class Client
     {
 
         // Check port validity
-        if (!is_int($port) || $port <= 0 || $port > 65535) {
+        if (! is_int($port) || $port <= 0 || $port > 65535) {
             throw new Exception\ProxyError('Invalid proxy port of ' . $port . ' specified.');
         }
 
@@ -341,7 +338,7 @@ class Client
         }
 
         $valid_requests = ['get', 'post', 'put', 'delete'];
-        if (!in_array($method, $valid_requests))
+        if (! in_array($method, $valid_requests))
             throw new Exception\InvalidMethod(sprintf('Invalid HTTP method "%s" specified.', $method));
 
         try {

--- a/src/Nessus/Client.php
+++ b/src/Nessus/Client.php
@@ -160,8 +160,9 @@ Class Client
         $this->url .= ':' . $this->port . '/';
 
         // Check that we have a valid host
-        if (!filter_var($this->url, FILTER_VALIDATE_URL))
+        if (!filter_var($this->url, FILTER_VALIDATE_URL)) {
             throw new Exception\InvalidUrl($this->url . ' appears to be unparsable.');
+        }
     }
 
     /**
@@ -196,12 +197,14 @@ Class Client
     {
 
         // Check port validity
-        if (!is_int($port) || $port <= 0 || $port > 65535)
+        if (!is_int($port) || $port <= 0 || $port > 65535) {
             throw new Exception\ProxyError('Invalid proxy port of ' . $port . ' specified.');
+        }
 
         // Ensure that we have proxy host:port defined
-        if (is_null($host) || is_null($port))
+        if (is_null($host) || is_null($port)) {
             throw new Exception\ProxyError('A host and port specification is required for proxy use.');
+        }
 
         $this->proxy_host = $host;
         $this->proxy_port = $port;
@@ -224,8 +227,9 @@ Class Client
     {
 
         // Ensure that we have proxy host:port defined
-        if (is_null($this->proxy_host) || is_null($this->proxy_port))
+        if (is_null($this->proxy_host) || is_null($this->proxy_port)) {
             throw new Exception\ProxyError('A host and port specification is required for proxy use.');
+        }
 
         $this->use_proxy = $use;
 
@@ -269,9 +273,11 @@ Class Client
         // Ensure the location is lowercase
         $this->call .= strtolower($location) . '/';
 
-        if (count($slug) > 0)
-            foreach ($slug as $slug_value)
+        if (count($slug) > 0) {
+            foreach ($slug as $slug_value) {
                 $this->call .= $slug_value . '/';
+            }
+        }
 
         return $this;
     }
@@ -330,8 +336,9 @@ Class Client
 
         $method = strtolower($method);
 
-        if ($raw)
+        if ($raw) {
             $this->raw = true;
+        }
 
         $valid_requests = ['get', 'post', 'put', 'delete'];
         if (!in_array($method, $valid_requests))

--- a/src/Nessus/Client.php
+++ b/src/Nessus/Client.php
@@ -25,7 +25,7 @@ SOFTWARE.
 
 namespace Nessus;
 
-/*
+/**
  * PHP Nessus NG
  *
  * @package  PHPNessusNG

--- a/src/Nessus/Exception/FailedNessusRequest.php
+++ b/src/Nessus/Exception/FailedNessusRequest.php
@@ -25,7 +25,7 @@ SOFTWARE.
 
 namespace Nessus\Exception;
 
-/**
+/*
  * PHP Nessus NG.
  *
  * @package  PHPNessusNG

--- a/src/Nessus/Exception/FailedNessusRequest.php
+++ b/src/Nessus/Exception/FailedNessusRequest.php
@@ -33,9 +33,9 @@ namespace Nessus\Exception;
  * @license  MIT
  * @link     https://leonjza.github.io/
  */
-use Guzzle\Http\Exception\BadResponseException;
-use Guzzle\Http\Message\Request;
-use Guzzle\Http\Message\Response;
+use GuzzleHttp\Exception\BadResponseException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * FailedNessusRequest Exception
@@ -43,15 +43,13 @@ use Guzzle\Http\Message\Response;
 class FailedNessusRequest extends BadResponseException
 {
 
-    public static function exceptionFactory($message, Request $request, Response $response)
+    public static function exceptionFactory($message, RequestInterface $request, ResponseInterface $response = null)
     {
 
         $exceptionClass = __CLASS__;
 
         /** @var BadResponseException $exception */
-        $exception = new $exceptionClass($message);
-        $exception->setRequest($request);
-        $exception->setResponse($response);
+        $exception = new $exceptionClass($message, $request, $response);
 
         return $exception;
     }

--- a/src/Nessus/Exception/FailedNessusRequest.php
+++ b/src/Nessus/Exception/FailedNessusRequest.php
@@ -25,14 +25,15 @@ SOFTWARE.
 
 namespace Nessus\Exception;
 
-/*
- * PHP Nessus NG
+/**
+ * PHP Nessus NG.
  *
  * @package  PHPNessusNG
  * @author   Leon Jacobs <@leonjza>
  * @license  MIT
  * @link     https://leonjza.github.io/
  */
+
 use GuzzleHttp\Exception\BadResponseException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/src/Nessus/Nessus/Call.php
+++ b/src/Nessus/Nessus/Call.php
@@ -25,7 +25,7 @@ SOFTWARE.
 
 namespace Nessus\Nessus;
 
-/*
+/**
  * PHP Nessus NG
  *
  * @package  PHPNessusNG

--- a/src/Nessus/Nessus/Call.php
+++ b/src/Nessus/Nessus/Call.php
@@ -25,7 +25,7 @@ SOFTWARE.
 
 namespace Nessus\Nessus;
 
-/**
+/*
  * PHP Nessus NG
  *
  * @package  PHPNessusNG
@@ -46,7 +46,6 @@ use Nessus\Exception;
  */
 class Call
 {
-
     /**
      * Authenticates to a Nessus Scanner, saving the token that was received.
      *
@@ -89,8 +88,8 @@ class Call
             'verify'   => $scope->validate_cert,
             'timeout'  => $scope->timeout,
             'headers'  => [
-                'User-Agent' => 'PHPNessusNG/' . $scope->version
-            ]
+                'User-Agent' => 'PHPNessusNG/' . $scope->version,
+            ],
         ];
 
         // Detect if we have a proxy configured
@@ -98,7 +97,7 @@ class Call
 
             // If we have a username or password, add it to the proxy
             // setting
-            if (!is_null($scope->proxy_user) || !is_null($scope->proxy_pass)) {
+            if (! is_null($scope->proxy_user) || ! is_null($scope->proxy_pass)) {
                 $config['proxy'] = 'tcp://' . $scope->proxy_user . ':' . $scope->proxy_pass .
                                    '@' . $scope->proxy_host . ':' . $scope->proxy_port;
             } else {
@@ -128,14 +127,14 @@ class Call
     public function request(HttpClient $client, $method, $scope, $no_token = false)
     {
         // Define the uri and default options
-        $method  = strtoupper($method);
-        $uri     = $scope->call;
+        $method = strtoupper($method);
+        $uri = $scope->call;
         $options = ['headers' => ['Accept' => 'application/json']];
 
         // If we have $no_token set, we assume that this is the login request
         // that we have received. So, we will override the body with the
         // username and password
-        if (!$no_token) {
+        if (! $no_token) {
             // Only really needed by $this->token() method. Otherwise we have
             // a cyclic dependency trying to setup a token
             $options['headers']['X-Cookie'] = 'token=' . $this->token($scope);
@@ -149,10 +148,10 @@ class Call
             }
         } else {
             // $no_token may mean a token request
-            $uri             = 'session/';
+            $uri = 'session/';
             $options['json'] = [
                 'username' => $scope->username,
-                'password' => $scope->password
+                'password' => $scope->password,
             ];
         }
 
@@ -193,7 +192,7 @@ class Call
 
         // If the response is requested in raw format, return it. We need
         // to be careful to not return raw to a token request too.
-        if ($scope->raw && !$no_token) {
+        if ($scope->raw && ! $no_token) {
             return (string) $response->getBody();
         }
 
@@ -202,7 +201,6 @@ class Call
         if (is_null($response->getBody()) || trim($response->getBody()) == 'null') {
             return null;
         }
-
 
         // We assume that Nessus can return empty bodies and that Nessus will
         // use HTTP status codes to inform us whether the request failed.

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -74,13 +74,14 @@ class ClientTest extends TestCase
     /**
      * Test sending a request that returns a BadResponseException.
      *
-     * @expectedException \Guzzle\Http\Exception\BadResponseException
+     * @expectedException \GuzzleHttp\Exception\BadResponseException
      */
     public function testMakeApiCallBadResponse()
     {
+        $mockHttpBadResponseException = \Mockery::mock('\GuzzleHttp\Exception\BadResponseException');
 
         $this->mockCall
-            ->shouldReceive('call')->with('get', $this->mockClient)->andThrow('\Guzzle\Http\Exception\BadResponseException');
+            ->shouldReceive('call')->with('get', $this->mockClient)->andThrow($mockHttpBadResponseException);
 
         $this->mockClient->makeApiCall($this->mockCall, 'get', true);
     }

--- a/tests/unit/Nessus/CallTest.php
+++ b/tests/unit/Nessus/CallTest.php
@@ -419,6 +419,35 @@ class CallTest extends TestCase
     }
 
     /**
+     * Test failed request - connect exception.
+     *
+     * @expectedException \Nessus\Exception\FailedConnection
+     */
+    public function testRequestConnectionException()
+    {
+
+        $this->mockClient->call = 'foobar/';
+        $headers = ['X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json'];
+        $options = ['headers' => $headers, 'query' => $this->mockClient->fields];
+
+        $mockPsrHttpResponse = Mockery::mock('Psr\Http\Message\ResponseInterface');
+        $mockPsrHttpResponse
+            ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(400);
+
+        $mockHttpBadResponseException = Mockery::mock('\GuzzleHttp\Exception\ConnectException');
+
+        /** @var \Mockery\Mock|\GuzzleHttp\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\GuzzleHttp\Client');
+        $mockHttpClient
+            ->shouldReceive('request')->with('GET', $this->mockClient->call, $options)->andThrow($mockHttpBadResponseException);
+
+        $this->mockCall
+            ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
+
+        $this->assertEquals(['1', '2', '3'], $this->mockCall->request($mockHttpClient, 'get', $this->mockClient));
+    }
+
+    /**
      * Test failed request - JSON parse error (syntax error).
      *
      * @expectedException \InvalidArgumentException

--- a/tests/unit/Nessus/CallTest.php
+++ b/tests/unit/Nessus/CallTest.php
@@ -56,7 +56,7 @@ class CallTest extends TestCase
     /**
      * Test token retrieval from Nessus Scanner - bad response exception.
      *
-     * @expectedException \Guzzle\Http\Exception\BadResponseException
+     * @expectedException \GuzzleHttp\Exception\BadResponseException
      */
     public function testTokenNoTokenBadResponse()
     {
@@ -64,9 +64,11 @@ class CallTest extends TestCase
         $response = new stdClass();
         $response->token = 'foobar';
 
+        $mockHttpBadResponseException = \Mockery::mock('\GuzzleHttp\Exception\BadResponseException');
+
         $this->mockClient->token = null;
         $this->mockCall
-            ->shouldReceive('call')->with('post', $this->mockClient, true)->andThrow('\Guzzle\Http\Exception\BadResponseException');
+            ->shouldReceive('call')->with('post', $this->mockClient, true)->andThrow($mockHttpBadResponseException);
 
         $this->mockCall->token($this->mockClient);
 
@@ -94,7 +96,7 @@ class CallTest extends TestCase
     {
 
         $this->mockCall
-            ->shouldReceive('request')->with(Mockery::type('Guzzle\Http\Client'), 'get', $this->mockClient, false);
+            ->shouldReceive('request')->with(Mockery::type('GuzzleHttp\Client'), 'get', $this->mockClient, false);
 
         $this->mockCall->call('get', $this->mockClient);
     }
@@ -106,23 +108,18 @@ class CallTest extends TestCase
     {
         $this->mockClient->call = 'foobar/';
         $headers = ['X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json'];
+        $options = ['headers' => $headers, 'query' => $this->mockClient->fields];
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
-        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        /** @var \Mockery\Mock|Psr\Http\Message\ResponseInterface $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('Psr\Http\Message\ResponseInterface');
         $mockHttpResponse
             ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200)
-            ->shouldReceive('isSuccessful')->withNoArgs()->andReturn(true)
             ->shouldReceive('getBody')->withNoArgs()->andReturn(json_encode(['1', '2', '3']));
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
-        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
-        $mockHttpRequest
-            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
-
-        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
-        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        /** @var \Mockery\Mock|\GuzzleHttp\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\GuzzleHttp\Client');
         $mockHttpClient
-            ->shouldReceive('get')->with($this->mockClient->call, $headers, $this->mockClient->fields)->andReturn($mockHttpRequest);
+            ->shouldReceive('request')->with('GET', $this->mockClient->call, $options)->andReturn($mockHttpResponse);
 
         $this->mockCall
             ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
@@ -137,23 +134,18 @@ class CallTest extends TestCase
     {
         $this->mockClient->call = 'foobar/';
         $headers = ['X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json'];
+        $options = ['headers' => $headers, 'query' => $this->mockClient->fields];
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
-        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        /** @var \Mockery\Mock|Psr\Http\Message\ResponseInterface $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('Psr\Http\Message\ResponseInterface');
         $mockHttpResponse
             ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200)
-            ->shouldReceive('isSuccessful')->withNoArgs()->andReturn(true)
             ->shouldReceive('getBody')->withNoArgs()->andReturn('');
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
-        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
-        $mockHttpRequest
-            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
-
-        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
-        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        /** @var \Mockery\Mock|\GuzzleHttp\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\GuzzleHttp\Client');
         $mockHttpClient
-            ->shouldReceive('get')->with($this->mockClient->call, $headers, $this->mockClient->fields)->andReturn($mockHttpRequest);
+            ->shouldReceive('request')->with('GET', $this->mockClient->call, $options)->andReturn($mockHttpResponse);
 
         $this->mockCall
             ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
@@ -168,24 +160,18 @@ class CallTest extends TestCase
     {
         $this->mockClient->call = 'foobar/';
         $headers = ['X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json'];
+        $options = ['headers' => $headers, 'json' => $this->mockClient->fields];
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
-        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        /** @var \Mockery\Mock|Psr\Http\Message\ResponseInterface $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('Psr\Http\Message\ResponseInterface');
         $mockHttpResponse
             ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200)
-            ->shouldReceive('isSuccessful')->withNoArgs()->andReturn(true)
             ->shouldReceive('getBody')->withNoArgs()->andReturn(json_encode(['1', '2', '3']));
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
-        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
-        $mockHttpRequest
-            ->shouldReceive('setBody')->with(json_encode($this->mockClient->fields), 'application/json')
-            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
-
-        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
-        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        /** @var \Mockery\Mock|\GuzzleHttp\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\GuzzleHttp\Client');
         $mockHttpClient
-            ->shouldReceive('post')->with($this->mockClient->call, $headers)->andReturn($mockHttpRequest);
+            ->shouldReceive('request')->with('POST', $this->mockClient->call, $options)->andReturn($mockHttpResponse);
 
         $this->mockCall
             ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
@@ -200,24 +186,18 @@ class CallTest extends TestCase
     {
         $this->mockClient->call = 'foobar/';
         $headers = ['X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json'];
+        $options = ['headers' => $headers, 'json' => $this->mockClient->fields];
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
-        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        /** @var \Mockery\Mock|Psr\Http\Message\ResponseInterface $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('Psr\Http\Message\ResponseInterface');
         $mockHttpResponse
             ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200)
-            ->shouldReceive('isSuccessful')->withNoArgs()->andReturn(true)
             ->shouldReceive('getBody')->withNoArgs()->andReturn('');
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
-        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
-        $mockHttpRequest
-            ->shouldReceive('setBody')->with(json_encode($this->mockClient->fields), 'application/json')
-            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
-
-        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
-        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        /** @var \Mockery\Mock|\GuzzleHttp\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\GuzzleHttp\Client');
         $mockHttpClient
-            ->shouldReceive('put')->with($this->mockClient->call, $headers)->andReturn($mockHttpRequest);
+            ->shouldReceive('request')->with('PUT', $this->mockClient->call, $options)->andReturn($mockHttpResponse);
 
         $this->mockCall
             ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
@@ -232,24 +212,18 @@ class CallTest extends TestCase
     {
         $this->mockClient->call = 'foobar/';
         $headers = ['X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json'];
+        $options = ['headers' => $headers, 'json' => $this->mockClient->fields];
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
-        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        /** @var \Mockery\Mock|Psr\Http\Message\ResponseInterface $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('Psr\Http\Message\ResponseInterface');
         $mockHttpResponse
             ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200)
-            ->shouldReceive('isSuccessful')->withNoArgs()->andReturn(true)
             ->shouldReceive('getBody')->withNoArgs()->andReturn('');
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
-        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
-        $mockHttpRequest
-            ->shouldReceive('setBody')->with(json_encode($this->mockClient->fields), 'application/json')
-            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
-
-        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
-        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        /** @var \Mockery\Mock|\GuzzleHttp\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\GuzzleHttp\Client');
         $mockHttpClient
-            ->shouldReceive('post')->with($this->mockClient->call, $headers)->andReturn($mockHttpRequest);
+            ->shouldReceive('request')->with('POST', $this->mockClient->call, $options)->andReturn($mockHttpResponse);
 
         $this->mockCall
             ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
@@ -264,24 +238,18 @@ class CallTest extends TestCase
     {
         $this->mockClient->call = 'foobar/';
         $headers = ['X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json'];
+        $options = ['headers' => $headers, 'json' => $this->mockClient->fields];
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
-        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        /** @var \Mockery\Mock|Psr\Http\Message\ResponseInterface $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('Psr\Http\Message\ResponseInterface');
         $mockHttpResponse
             ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200)
-            ->shouldReceive('isSuccessful')->withNoArgs()->andReturn(true)
             ->shouldReceive('getBody')->withNoArgs()->andReturn('');
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
-        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
-        $mockHttpRequest
-            ->shouldReceive('setBody')->with(json_encode($this->mockClient->fields), 'application/json')
-            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
-
-        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
-        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        /** @var \Mockery\Mock|\GuzzleHttp\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\GuzzleHttp\Client');
         $mockHttpClient
-            ->shouldReceive('delete')->with($this->mockClient->call, $headers)->andReturn($mockHttpRequest);
+            ->shouldReceive('request')->with('DELETE', $this->mockClient->call, $options)->andReturn($mockHttpResponse);
 
         $this->mockCall
             ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
@@ -299,24 +267,18 @@ class CallTest extends TestCase
         $this->mockClient->password = 'bar';
         $postBody = ['username' => $this->mockClient->username, 'password' => $this->mockClient->password];
         $headers = ['Accept' => 'application/json'];
+        $options = ['headers' => $headers, 'json' => $postBody];
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
-        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        /** @var \Mockery\Mock|Psr\Http\Message\ResponseInterface $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('Psr\Http\Message\ResponseInterface');
         $mockHttpResponse
             ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200)
-            ->shouldReceive('isSuccessful')->withNoArgs()->andReturn(true)
             ->shouldReceive('getBody')->withNoArgs()->andReturn(json_encode(['1', '2', '3']));
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
-        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
-        $mockHttpRequest
-            ->shouldReceive('setBody')->with(json_encode($postBody), 'application/json')
-            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
-
-        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
-        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        /** @var \Mockery\Mock|\GuzzleHttp\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\GuzzleHttp\Client');
         $mockHttpClient
-            ->shouldReceive('post')->with('session/', $headers)->andReturn($mockHttpRequest);
+            ->shouldReceive('request')->with('POST', 'session/', $options)->andReturn($mockHttpResponse);
 
         $this->mockCall
             ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
@@ -332,28 +294,27 @@ class CallTest extends TestCase
     public function testRequestBadResponse()
     {
 
-        $mockHttpBadResponseException = Mockery::mock('\Guzzle\Http\Exception\BadResponseException');
+        $mockPsrHttpResponse = Mockery::mock('Psr\Http\Message\ResponseInterface');
+        $mockPsrHttpResponse->shouldReceive('getStatusCode')->withNoArgs()->andReturn(403);
+
+        $mockHttpBadResponseException = Mockery::mock('\GuzzleHttp\Exception\BadResponseException');
         $mockHttpBadResponseException
-            ->shouldReceive('getRequest')->withNoArgs()->andReturn(Mockery::mock('\Guzzle\Http\Message\Request'))
-            ->shouldReceive('getResponse')->withNoArgs()->andReturn(Mockery::mock('\Guzzle\Http\Message\Response'));
+            ->shouldReceive('getRequest')->withNoArgs()->andReturn(Mockery::mock('Psr\Http\Message\RequestInterface'))
+            ->shouldReceive('getResponse')->withNoArgs()->andReturn($mockPsrHttpResponse);
 
         $this->mockClient->call = 'foobar/';
         $headers = ['X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json'];
+        $options = ['headers' => $headers, 'query' => $this->mockClient->fields];
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
-        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        /** @var \Mockery\Mock|Psr\Http\Message\ResponseInterface $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('Psr\Http\Message\ResponseInterface');
         $mockHttpResponse
             ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200);
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
-        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
-        $mockHttpRequest
-            ->shouldReceive('send')->withNoArgs()->andThrow($mockHttpBadResponseException);
-
-        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
-        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        /** @var \Mockery\Mock|\GuzzleHttp\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\GuzzleHttp\Client');
         $mockHttpClient
-            ->shouldReceive('get')->with($this->mockClient->call, $headers, $this->mockClient->fields)->andReturn($mockHttpRequest);
+            ->shouldReceive('request')->with('GET', $this->mockClient->call, $options)->andThrow($mockHttpBadResponseException);
 
         $this->mockCall
             ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
@@ -371,21 +332,21 @@ class CallTest extends TestCase
 
         $this->mockClient->call = 'foobar/';
         $headers = ['X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json'];
+        $options = ['headers' => $headers, 'query' => $this->mockClient->fields];
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
-        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
-        $mockHttpResponse
+        $mockPsrHttpResponse = Mockery::mock('Psr\Http\Message\ResponseInterface');
+        $mockPsrHttpResponse
             ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(404);
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
-        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
-        $mockHttpRequest
-            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
+        $mockHttpBadResponseException = Mockery::mock('\GuzzleHttp\Exception\ClientException');
+        $mockHttpBadResponseException
+            ->shouldReceive('getRequest')->withNoArgs()->andReturn(Mockery::mock('Psr\Http\Message\RequestInterface'))
+            ->shouldReceive('getResponse')->withNoArgs()->andReturn($mockPsrHttpResponse);
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
-        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        /** @var \Mockery\Mock|\GuzzleHttp\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\GuzzleHttp\Client');
         $mockHttpClient
-            ->shouldReceive('get')->with($this->mockClient->call, $headers, $this->mockClient->fields)->andReturn($mockHttpRequest);
+            ->shouldReceive('request')->with('GET', $this->mockClient->call, $options)->andThrow($mockHttpBadResponseException);
 
         $this->mockCall
             ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
@@ -394,31 +355,62 @@ class CallTest extends TestCase
     }
 
     /**
-     * Test failed request - response unsuccessful.
+     * Test failed request - client exception.
      *
      * @expectedException \Nessus\Exception\FailedNessusRequest
      */
-    public function testRequestUnsuccessfulResponse()
+    public function testRequestClientException()
     {
 
         $this->mockClient->call = 'foobar/';
         $headers = ['X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json'];
+        $options = ['headers' => $headers, 'query' => $this->mockClient->fields];
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
-        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
-        $mockHttpResponse
-            ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200)
-            ->shouldReceive('isSuccessful')->withNoArgs()->andReturn(false);
+        $mockPsrHttpResponse = Mockery::mock('Psr\Http\Message\ResponseInterface');
+        $mockPsrHttpResponse
+            ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(400);
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
-        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
-        $mockHttpRequest
-            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
+        $mockHttpBadResponseException = Mockery::mock('\GuzzleHttp\Exception\ClientException');
+        $mockHttpBadResponseException
+            ->shouldReceive('getRequest')->withNoArgs()->andReturn(Mockery::mock('Psr\Http\Message\RequestInterface'))
+            ->shouldReceive('getResponse')->withNoArgs()->andReturn($mockPsrHttpResponse);
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
-        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        /** @var \Mockery\Mock|\GuzzleHttp\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\GuzzleHttp\Client');
         $mockHttpClient
-            ->shouldReceive('get')->with($this->mockClient->call, $headers, $this->mockClient->fields)->andReturn($mockHttpRequest);
+            ->shouldReceive('request')->with('GET', $this->mockClient->call, $options)->andThrow($mockHttpBadResponseException);
+
+        $this->mockCall
+            ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
+
+        $this->assertEquals(['1', '2', '3'], $this->mockCall->request($mockHttpClient, 'get', $this->mockClient));
+    }
+
+    /**
+     * Test failed request - server exception.
+     *
+     * @expectedException \Nessus\Exception\FailedNessusRequest
+     */
+    public function testRequestServerException()
+    {
+
+        $this->mockClient->call = 'foobar/';
+        $headers = ['X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json'];
+        $options = ['headers' => $headers, 'query' => $this->mockClient->fields];
+
+        $mockPsrHttpResponse = Mockery::mock('Psr\Http\Message\ResponseInterface');
+        $mockPsrHttpResponse
+            ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(400);
+
+        $mockHttpBadResponseException = Mockery::mock('\GuzzleHttp\Exception\ServerException');
+        $mockHttpBadResponseException
+            ->shouldReceive('getRequest')->withNoArgs()->andReturn(Mockery::mock('Psr\Http\Message\RequestInterface'))
+            ->shouldReceive('getResponse')->withNoArgs()->andReturn($mockPsrHttpResponse);
+
+        /** @var \Mockery\Mock|\GuzzleHttp\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\GuzzleHttp\Client');
+        $mockHttpClient
+            ->shouldReceive('request')->with('GET', $this->mockClient->call, $options)->andThrow($mockHttpBadResponseException);
 
         $this->mockCall
             ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');
@@ -429,29 +421,24 @@ class CallTest extends TestCase
     /**
      * Test failed request - JSON parse error (syntax error).
      *
-     * @expectedException \Nessus\Exception\FailedNessusRequest
+     * @expectedException \InvalidArgumentException
      */
     public function testRequestFailedJsonParse()
     {
         $this->mockClient->call = 'foobar/';
         $headers = ['X-Cookie' => 'token=X-Cookie-Token', 'Accept' => 'application/json'];
+        $options = ['headers' => $headers, 'query' => $this->mockClient->fields];
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Response $mockHttpResponse */
-        $mockHttpResponse = Mockery::mock('\Guzzle\Http\Message\Response');
+        /** @var \Mockery\Mock|Psr\Http\Message\ResponseInterface $mockHttpResponse */
+        $mockHttpResponse = Mockery::mock('Psr\Http\Message\ResponseInterface');
         $mockHttpResponse
             ->shouldReceive('getStatusCode')->withNoArgs()->andReturn(200)
-            ->shouldReceive('isSuccessful')->withNoArgs()->andReturn(true)
             ->shouldReceive('getBody')->withNoArgs()->andReturn('}INVALID JSON{');
 
-        /** @var \Mockery\Mock|\Guzzle\Http\Message\Request $mockHttpRequest */
-        $mockHttpRequest = Mockery::mock('\Guzzle\Http\Message\Request');
-        $mockHttpRequest
-            ->shouldReceive('send')->withNoArgs()->andReturn($mockHttpResponse);
-
-        /** @var \Mockery\Mock|\Guzzle\Http\Client $mockHttpClient */
-        $mockHttpClient = Mockery::mock('\Guzzle\Http\Client');
+        /** @var \Mockery\Mock|\GuzzleHttp\Client $mockHttpClient */
+        $mockHttpClient = Mockery::mock('\GuzzleHttp\Client');
         $mockHttpClient
-            ->shouldReceive('get')->with($this->mockClient->call, $headers, $this->mockClient->fields)->andReturn($mockHttpRequest);
+            ->shouldReceive('request')->with('GET', $this->mockClient->call, $options)->andReturn($mockHttpResponse);
 
         $this->mockCall
             ->shouldReceive('token')->with($this->mockClient)->andReturn('X-Cookie-Token');


### PR DESCRIPTION
PHPNessusNG was still using Guzzle ~v3.0, this PR will bring it up to using ~v6.0 (the latest version of Guzzle).

These changes should make no difference to a user of PHPNessusNG except that they will be able to use Guzzle 6 with PHPNessusNG.